### PR TITLE
Add SPDX tags for license related information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 zichy
+Copyright (c) 2022-2023 zichy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/fieber.css
+++ b/fieber.css
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: MIT
+   SPDX-FileCopyrightText: Copyright (c) 2022-2023 zichy
+*/
 /* Custom properties
 ========================================
 */

--- a/index.html
+++ b/index.html
@@ -1,3 +1,7 @@
+<!--
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2022-2023 zichy
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
This is essentially in the spirit of the GPL's recommendation to describe the license of the current file in its header, albeit machine readable and briefer.

See:

- https://spdx.dev/ids/
- https://spdx.dev/spdx-specification-21-web-version/#h.206ipza
- https://github.com/spdx/spdx-spec/blob/development/v2.2.2/examples/SPDXTagExample-v2.2.spdx